### PR TITLE
Making package branch variable

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,5 +1,6 @@
 ---
 # defaults file for cloud-monitoring-agent
+cloud_monitoring_agent_repo_branch: stable
 cloud_monitoring_agent_force_setup: False
 cloud_monitoring_default_checks:
   - filesystem

--- a/tasks/Debian.yml
+++ b/tasks/Debian.yml
@@ -7,11 +7,11 @@
   apt_key: id=D05AB914 url='https://monitoring.api.rackspacecloud.com/pki/agent/linux.asc' state=present
 
 - name: Ubuntu | setup monitoring agent apt repository
-  apt_repository: repo='deb http://stable.packages.cloudmonitoring.rackspace.com/{{ ansible_distribution | lower }}-{{ ansible_distribution_version }}-x86_64 cloudmonitoring main' state=present
+  apt_repository: repo='deb http://{{ cloud_monitoring_agent_repo_branch }}.packages.cloudmonitoring.rackspace.com/{{ ansible_distribution | lower }}-{{ ansible_distribution_version }}-x86_64 cloudmonitoring main' state=present
   when: ansible_distribution == "Ubuntu"
 
 - name: Debian | setup monitoring agent apt repository
-  apt_repository: repo='deb http://stable.packages.cloudmonitoring.rackspace.com/{{ ansible_distribution | lower }}-{{ ansible_distribution_release }}-x86_64 cloudmonitoring main' state=present
+  apt_repository: repo='deb http://{{ cloud_monitoring_agent_repo_branch }}.packages.cloudmonitoring.rackspace.com/{{ ansible_distribution | lower }}-{{ ansible_distribution_release }}-x86_64 cloudmonitoring main' state=present
   when: ansible_distribution == "Debian"
 
 - name: Debian | install monitoring agent

--- a/templates/RedHat.repo.j2
+++ b/templates/RedHat.repo.j2
@@ -1,4 +1,4 @@
 [rackspace] 
 name=Rackspace Monitoring 
-baseurl=http://stable.packages.cloudmonitoring.rackspace.com/{{ ansible_distribution | lower }}-{{ ansible_distribution_major_version }}-x86_64 
+baseurl=http://{{ cloud_monitoring_agent_repo_branch }}.packages.cloudmonitoring.rackspace.com/{{ ansible_distribution | lower }}-{{ ansible_distribution_major_version }}-x86_64 
 enabled=1


### PR DESCRIPTION
<h2>Why</h2>

We need a way for pushing test agent bundles to servers for automated testing. 

<h2>How</h2>

Making the branch a variable will allow us to selectively install agent bundles on test servers. Added a default var to defaults which defaults to the status quo (stable)